### PR TITLE
Issue #4 - zookeeper authorization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ If your zookeeper path requires authorization you have to specify additional `au
 akka.cluster.seed.zookeeper {
     authorization {
         scheme = "digest"
-        auth = "username:bar"
+        auth = "username:secret"
     }
 }
 ``` 

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,19 @@ akka.cluster.seed.zookeeper {
 
 ```
 
+If your zookeeper path requires authorization you have to specify additional `authorization` section:
+
+
+```
+// application.conf
+akka.cluster.seed.zookeeper {
+    authorization {
+        scheme = "digest"
+        auth = "username:bar"
+    }
+}
+``` 
+
 
 details
 -------

--- a/src/test/scala/akka/cluster/seed/ZookeeperClusterSeedSettingsSpec.scala
+++ b/src/test/scala/akka/cluster/seed/ZookeeperClusterSeedSettingsSpec.scala
@@ -1,0 +1,28 @@
+package akka.cluster.seed
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import com.typesafe.config.{ConfigFactory, Config}
+import org.scalatest.{Matchers, WordSpecLike}
+
+class ZookeeperClusterSeedSettingsSpec extends TestKit(ActorSystem("test", ZookeeperClusterSeedSettingsSpec.config))
+  with WordSpecLike with Matchers {
+
+  "ZookeeperClusterSeedSettings " should {
+    "parse authentication options from config" in {
+      val settings = new ZookeeperClusterSeedSettings(system)
+      settings.ZKAuthorization should be(Some("digest", "foo:bar"))
+    }
+  }
+}
+
+object ZookeeperClusterSeedSettingsSpec {
+  val config: Config = ConfigFactory.parseString("""
+         akka.cluster.seed.zookeeper {
+             authorization {
+               scheme = "digest"
+               auth = "foo:bar"
+             }
+         }
+       """)
+}


### PR DESCRIPTION
Added optional authorization 
```
akka.cluster.seed.zookeeper {
  authorization {
    scheme = "digest"
    auth = "username:secret"
  }
}
```