### PR TITLE
Added support for alternative exhibitor request paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "com.sclasen"
 
 name := "akka-zk-cluster-seed"
 
-version := "0.1.4-SNAPSHOT"
+version := "0.1.5-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,21 @@ akka.cluster.seed.zookeeper {
 
 ```
 
+If you require a different exhibitor request path than the default `/exhibitor/v1/cluster/list`
+
+```
+// application.conf
+akka.cluster.seed.zookeeper {
+    path = "/akka/cluster/seed"
+    exhibitor {
+        url = "https://user:pass@host:port
+        request-path = "/my/custom/path"
+        validate-certs = true|false
+    }
+}
+
+```
+
 If your zookeeper path requires authorization you have to specify additional `authorization` section:
 
 

--- a/src/it/scala/akka/cluster/seed/ExhibitorClientSpec.scala
+++ b/src/it/scala/akka/cluster/seed/ExhibitorClientSpec.scala
@@ -17,7 +17,7 @@ class ExhibitorClientSpec extends WordSpec with MustMatchers with BeforeAndAfter
 
   "ExhibitorClient" must {
     "read the zookeepers from exhibitor" in {
-      val zks = ExhibitorClient(system, sys.env("EXHIBITOR_URL"), false).getZookeepers(Some("chroot")).futureValue
+      val zks = ExhibitorClient(system, sys.env("EXHIBITOR_URL"), "/exhibitor/v1/cluster/list", false).getZookeepers(Some("chroot")).futureValue
       zks must endWith("/chroot")
       zks must not startWith("/chroot")
     }

--- a/src/main/scala/akka/cluster/seed/ExhibitorClient.scala
+++ b/src/main/scala/akka/cluster/seed/ExhibitorClient.scala
@@ -23,13 +23,13 @@ import DefaultJsonProtocol._
 import spray.json.JsonParser
 import java.security.cert.X509Certificate
 
-case class ExhibitorClient(system: ActorSystem, exhibitorUrl: String, validateCerts: Boolean) extends Client {
+case class ExhibitorClient(system: ActorSystem, exhibitorUrl: String, requestPath: String, validateCerts: Boolean) extends Client {
 
   val url = new URL(exhibitorUrl)
 
   implicit val dispatcher = system.dispatcher
 
-  def getZookeepers(chroot: Option[String] = None) = pipeline(HttpRequest(GET, "/exhibitor/v1/cluster/list"))(extractUrl).map {
+  def getZookeepers(chroot: Option[String] = None) = pipeline(HttpRequest(GET, requestPath))(extractUrl).map {
     url => chroot.map(url + "/" + _).getOrElse(url)
   }
 

--- a/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
+++ b/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
@@ -117,7 +117,8 @@ class ZookeeperClusterSeedSettings(system: ActorSystem) {
   val ZKUrl = if (zc.hasPath("exhibitor.url")) {
     val validate = zc.getBoolean("exhibitor.validate-certs")
     val exhibitorUrl = zc.getString("exhibitor.url")
-    Await.result(ExhibitorClient(system, exhibitorUrl, validate).getZookeepers(), 10 seconds)
+    val exhibitorPath = if(zc.hasPath("exhibitor.request-path")) zc.getString("exhibitor.request-path") else "/exhibitor/v1/cluster/list"
+    Await.result(ExhibitorClient(system, exhibitorUrl, exhibitorPath, validate).getZookeepers(), 10 seconds)
   } else zc.getString("url")
 
   val ZKPath = zc.getString("path")


### PR DESCRIPTION
Added a new optional field `request-path` to `akka.cluster.seed.zookeeper.exhibitor` that when provided will override the default path `/exhibitor/v1/cluster/list`