### PR TITLE
Fixed TimeoutException in tryJoin() 

### DIFF
--- a/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
+++ b/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
@@ -94,7 +94,11 @@ class ZookeeperClusterSeed(system: ExtendedActorSystem) extends Extension {
         joined.trySuccess(true)
       }
 
-      Await.result(joined.future, 10.seconds)
+      try {
+        Await.result(joined.future, 10.seconds)
+      } catch {
+        case _: TimeoutException => false
+      }
     }
   }
 


### PR DESCRIPTION
Now, you keep retrying to join the cluster when all seed are unreachable.