### PR TITLE
Fix exception during removal of ephemeral nodes on first start, when …

### DIFF
--- a/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
+++ b/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
@@ -120,7 +120,13 @@ class ZookeeperClusterSeed(system: ExtendedActorSystem) extends Extension {
    * Removes ephemeral nodes for self address that may exist when node restarts abnormally
    */
   def removeEphemeralNodes: Unit = {
-    client.getChildren.forPath(path).asScala
+    val ephemeralNodes = try {
+      client.getChildren.forPath(path).asScala
+    } catch {
+      case _: NoNodeException => Nil
+    }
+
+    ephemeralNodes
       .map(p => s"$path/$p")
       .map { p =>
         try {


### PR DESCRIPTION
If parent node for ephemeral nodes does not exist - application crashes. This fixes the crash