### PR TITLE
Patchset - upgrade to sbt 0.13.9 and fix build.sbt issues; remove from zookeeper as soon as removed from cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target
 project/target
 .env
+.ensime*

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,6 @@ import com.typesafe.sbt.SbtMultiJvm
 
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-organization := "com.sclasen"
-
 name := "akka-zk-cluster-seed"
 
 version := "0.1.6-SNAPSHOT"
@@ -14,72 +12,9 @@ scalaVersion := "2.11.7"
 
 crossScalaVersions := Seq("2.11.7", "2.10.4")
 
-parallelExecution in Test := false
+val akkaVersion      = "2.4.0"
 
-scalariformSettings
-
-libraryDependencies ++= (akkaDependencies ++ zkDependencies ++ testDependencies)
-
-parallelExecution in Test := false
-
-
-
-pomExtra := (
-  <url>http://github.com/sclasen/akka-zk-cluster-seed</url>
-    <licenses>
-      <license>
-        <name>The Apache Software License, Version 2.0</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <scm>
-      <url>git@github.com:sclasen/akka-zk-cluster-seed.git</url>
-      <connection>scm:git:git@github.com:sclasen/akka-zk-cluster-seed.git</connection>
-    </scm>
-    <developers>
-      <developer>
-        <id>sclasen</id>
-        <name>Scott Clasen</name>
-        <url>http://github.com/sclasen</url>
-      </developer>
-    </developers>)
-
-
-publishTo <<= version {
-  (v: String) =>
-    val nexus = "https://oss.sonatype.org/"
-    if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
-    else Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
-
-val root = rootProject
-
-def rootProject = Project("akka-zk-cluster-seed", file("."))
-  .settings(Project.defaultSettings:_*)
-  .settings(
-    scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-language:postfixOps"),
-    javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation")
-  )
-  .settings(Defaults.itSettings:_*)
-  .settings(SbtMultiJvm.multiJvmSettings:_*)
-  .settings(compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in IntegrationTest))
-  .settings(executeTests in IntegrationTest <<= (executeTests in Test, executeTests in MultiJvm) map {
-  case (testResults, multiNodeResults)  =>
-    val overall =
-      if (testResults.overall.id < multiNodeResults.overall.id)
-        multiNodeResults.overall
-      else
-        testResults.overall
-    Tests.Output(overall,
-      testResults.events ++ multiNodeResults.events,
-      testResults.summaries ++ multiNodeResults.summaries)
- })
-  .configs(IntegrationTest, MultiJvm)
-
-val akkaVersion           = "2.4.0"
-
-def akkaDependencies = Seq(
+val akkaDependencies = Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % "provided",
   "com.typesafe.akka" %% "akka-cluster" % akkaVersion % "provided",
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % "provided",
@@ -89,24 +24,76 @@ def akkaDependencies = Seq(
   "io.spray" %% "spray-client" % "1.3.2" % "provided"
 )
 
-def zkDependencies = Seq(
+val zkDependencies = Seq(
   "org.apache.curator" % "curator-framework" % "2.8.0" exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12"),
   "org.apache.curator" % "curator-recipes" % "2.8.0"  exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12")
 )
 
-def testDependencies = Seq(
-  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test,it,multi-jvm",
-  "com.typesafe.akka" %% "akka-actor" % akkaVersion % "test,it,multi-jvm",
-  "com.typesafe.akka" %% "akka-cluster" % akkaVersion % "test,it,multi-jvm",
-  "org.scalatest" %% "scalatest" % "2.1.6" % "test,it,multi-jvm",
-  "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % "test,it,multi-jvm",
-  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % "test,it,multi-jvm",
-  "org.slf4j" % "log4j-over-slf4j" % "1.7.7" % "test,it,multi-jvm",
-  "ch.qos.logback" % "logback-classic" % "1.1.2"  % "test,it,multi-jvm"
+val testDependencies = Seq(
+  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion % "test",
+  "com.typesafe.akka" %% "akka-cluster" % akkaVersion % "test",
+  "org.scalatest" %% "scalatest" % "2.1.6" % "test",
+  "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % "test",
+  "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % "test",
+  "org.slf4j" % "log4j-over-slf4j" % "1.7.7" % "test",
+  "ch.qos.logback" % "logback-classic" % "1.1.2"  % "test"
 )
 
+lazy val rootProject = (project in file(".")).
+  settings(
+    libraryDependencies ++= (akkaDependencies ++ zkDependencies ++ testDependencies),
+    scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-language:postfixOps"),
+    javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
+    organization := "com.sclasen",
+    name := "akka-zk-cluster-seed",
+    version := "0.1.5-SNAPSHOT",
+    scalaVersion := "2.11.7",
+    crossScalaVersions := Seq("2.11.7", "2.10.4"),
+    parallelExecution in Test := false,
+    // scalariformSettings
+    parallelExecution in Test := false,
 
+    pomExtra := (
+      <url>http://github.com/sclasen/akka-zk-cluster-seed</url>
+      <licenses>
+        <license>
+          <name>The Apache Software License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+      <scm>
+        <url>git@github.com:sclasen/akka-zk-cluster-seed.git</url>
+        <connection>scm:git:git@github.com:sclasen/akka-zk-cluster-seed.git</connection>
+      </scm>
+      <developers>
+        <developer>
+          <id>sclasen</id>
+          <name>Scott Clasen</name>
+          <url>http://github.com/sclasen</url>
+        </developer>
+      </developers>),
 
-// needs to come after all dependencies
-
-net.virtualvoid.sbt.graph.Plugin.graphSettings
+    publishTo <<= version {
+      (v: String) =>
+      val nexus = "https://oss.sonatype.org/"
+      if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
+      else Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    }
+  ).
+  settings(Defaults.itSettings:_*).
+  settings(SbtMultiJvm.multiJvmSettings:_*).
+  settings(compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in IntegrationTest)).
+  settings(executeTests in IntegrationTest <<= (executeTests in Test, executeTests in MultiJvm) map {
+    case (testResults, multiNodeResults)  =>
+      val overall =
+        if (testResults.overall.id < multiNodeResults.overall.id)
+          multiNodeResults.overall
+        else
+          testResults.overall
+      Tests.Output(overall,
+        testResults.events ++ multiNodeResults.events,
+        testResults.summaries ++ multiNodeResults.summaries)
+  }).
+  configs(IntegrationTest, MultiJvm)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,15 +2,11 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
-
-resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.8")
 


### PR DESCRIPTION
# Patch 1: Upgrade to sbt 0.13.9 and some dependencies

- sbt-idea should probably be included as a plugin in
  `~/.sbt/0.13/plugins/idea.sbt` or something, and not in the project
- Upgraded to the latest dependencyGraph project, which doesn't require
  anything in build.sbt in order to work
- Removed problematic (and unnecessary, at least with sbt `0.13.9`) inclusion of `Project.defaultSettings`, which breaks
  plugins such as `ensime-sbt`
- Consistently specify settings via the `project.settings` calls, instead
  of mixing methods.

# Patch 2: close the latch on member removed

Sometimes, an ActorSystem can fail to shutdown (because of a blocked thread). If zookeeper records are left behind after a complete shutdown, it takes about 30 seconds for them to expire as is. If the new cluster is started before those records are removed, then the nodes come up with the ghost of a past cluster impressed in their memory, and they will wait forever for that cluster to be available before they will try anything. In short, the akka cluster will fail to bootstrap.

Recognizing that this is a problem that unfortunately can't be solved completely, it can be reduced by removing the record as soon as Cluster departure is successful. I can't think of any good reasons why it should hang around and be a seed node after it left the cluster.