### PR TITLE
Artery support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.11.8")
 
-val akkaVersion = "2.4.9"
+val akkaVersion = "2.4.12"
 
 val akkaDependencies = Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,

--- a/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
+++ b/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
@@ -53,7 +53,7 @@ class ZookeeperClusterSeed(system: ExtendedActorSystem) extends Extension {
     client
   }
 
-  val myId = address.hostPort
+  val myId = s"${address.protocol}://${address.hostPort}"
 
   val path = s"${settings.ZKPath}/${system.name}"
 
@@ -103,7 +103,7 @@ class ZookeeperClusterSeed(system: ExtendedActorSystem) extends Extension {
       true
     } else {
       val seeds = latch.getParticipants.iterator().asScala.filterNot(_.getId == myId).map {
-        node => AddressFromURIString(s"akka.tcp://${node.getId}")
+        node => AddressFromURIString(node.getId)
       }.toList
       system.log.warning("component=zookeeper-cluster-seed at=join-cluster seeds={}", seeds)
       Cluster(system).joinSeedNodes(immutable.Seq(seeds: _*))

--- a/src/multi-jvm/scala/akka/cluster/seed/ScalaTestMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/akka/cluster/seed/ScalaTestMultiNodeSpec.scala
@@ -1,0 +1,14 @@
+package akka.cluster.seed.zookeeper
+
+import akka.remote.testkit.MultiNodeSpecCallbacks
+import org.scalatest._
+
+import scala.language.postfixOps
+
+trait ScalaTestMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpecLike with MustMatchers with BeforeAndAfterAll {
+
+  override def beforeAll() = multiNodeSpecBeforeAll()
+
+  override def afterAll() = multiNodeSpecAfterAll()
+
+}

--- a/src/multi-jvm/scala/akka/cluster/seed/ZookeeperClusterSeedArteryMultiJvm.scala
+++ b/src/multi-jvm/scala/akka/cluster/seed/ZookeeperClusterSeedArteryMultiJvm.scala
@@ -1,19 +1,15 @@
 package akka.cluster.seed.zookeeper
 
-import akka.remote.testkit.MultiNodeSpecCallbacks
-import akka.util.Timeout
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberUp}
+import akka.cluster.seed.ZookeeperClusterSeed
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
-import akka.actor._
-import com.typesafe.config.{ConfigFactory, Config}
-import akka.cluster.ClusterEvent.{CurrentClusterState, MemberUp}
-import akka.cluster.Cluster
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{Random, Properties}
-import akka.cluster.ClusterEvent.MemberUp
-import akka.cluster.seed.ZookeeperClusterSeed
-import concurrent.duration._
-import org.scalatest._
+import scala.util.{Properties, Random}
 
 
 object ZookeeperClusterSeedArteryMultiNodeConfig extends MultiNodeConfig {
@@ -46,8 +42,6 @@ class ZookeeperClusterSeedArteryMultiJvmNode4 extends ZookeeperClusterSeedArtery
 
 class ZookeeperClusterSeedArterySpec extends  MultiNodeSpec(ZookeeperClusterSeedArteryMultiNodeConfig)
 with ScalaTestMultiNodeSpec with ImplicitSender {
-
-  import ZookeeperClusterSeedArteryMultiNodeConfig._
 
   def initialParticipants = roles.size
 

--- a/src/multi-jvm/scala/akka/cluster/seed/ZookeeperClusterSeedArteryMultiJvm.scala
+++ b/src/multi-jvm/scala/akka/cluster/seed/ZookeeperClusterSeedArteryMultiJvm.scala
@@ -1,0 +1,72 @@
+package akka.cluster.seed.zookeeper
+
+import akka.remote.testkit.MultiNodeSpecCallbacks
+import akka.util.Timeout
+import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
+import akka.testkit.ImplicitSender
+import akka.actor._
+import com.typesafe.config.{ConfigFactory, Config}
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberUp}
+import akka.cluster.Cluster
+import scala.language.postfixOps
+import scala.util.{Random, Properties}
+import akka.cluster.ClusterEvent.MemberUp
+import akka.cluster.seed.ZookeeperClusterSeed
+import concurrent.duration._
+import org.scalatest._
+
+
+object ZookeeperClusterSeedArteryMultiNodeConfig extends MultiNodeConfig {
+  val node1 = role("node1")
+  val node2 = role("node2")
+  val node3 = role("node3")
+  val node4 = role("node4")
+
+  commonConfig(ConfigFactory.parseString(s"""
+    akka.cluster.seed.zookeeper.url = "${Properties.envOrElse("ZK_URL", "127.0.0.1:2181")}"
+    akka.cluster.seed.zookeeper.path = "/akka/cluster/arteryseed"
+    akka.loglevel = ${Properties.envOrElse("LOG_LEVEL", "INFO")}
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.loggers = ["akka.event.slf4j.Slf4jLogger"]
+    akka.remote.log-remote-lifecycle-events = off
+    akka.remote.artery.enabled = on
+    akka.log-dead-letters-during-shutdown = false
+    # don't use sigar for tests, native lib not in path
+    akka.cluster.metrics.collector-class = akka.cluster.JmxMetricsCollector
+                                         """))
+}
+
+class ZookeeperClusterSeedArteryMultiJvmNode1 extends ZookeeperClusterSeedArterySpec
+
+class ZookeeperClusterSeedArteryMultiJvmNode2 extends ZookeeperClusterSeedArterySpec
+
+class ZookeeperClusterSeedArteryMultiJvmNode3 extends ZookeeperClusterSeedArterySpec
+
+class ZookeeperClusterSeedArteryMultiJvmNode4 extends ZookeeperClusterSeedArterySpec
+
+class ZookeeperClusterSeedArterySpec extends  MultiNodeSpec(ZookeeperClusterSeedArteryMultiNodeConfig)
+with ScalaTestMultiNodeSpec with ImplicitSender {
+
+  import ZookeeperClusterSeedArteryMultiNodeConfig._
+
+  def initialParticipants = roles.size
+
+  "ZookeeperClusterSeed extension" must {
+
+    "bootstrap a Artery enabled cluster properly" in {
+      Cluster(system).subscribe(testActor, classOf[MemberUp])
+      expectMsgClass(classOf[CurrentClusterState])
+      Thread.sleep(Random.nextInt(1000))  //add some randomenss to when the joins happen
+      ZookeeperClusterSeed(system).join()
+      expectMsgClass(10 seconds, classOf[MemberUp])
+      expectMsgClass(classOf[MemberUp])
+      expectMsgClass(classOf[MemberUp])
+      expectMsgClass(classOf[MemberUp])
+      enterBarrier("up")
+      Cluster(system).readView.members.size must be(4)
+      enterBarrier("done")
+
+    }
+  }
+
+}

--- a/src/multi-jvm/scala/akka/cluster/seed/ZookeeperClusterSeedMultiJvm.scala
+++ b/src/multi-jvm/scala/akka/cluster/seed/ZookeeperClusterSeedMultiJvm.scala
@@ -1,30 +1,20 @@
 package akka.cluster.seed.zookeeper
 
-import akka.remote.testkit.MultiNodeSpecCallbacks
-import akka.util.Timeout
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberUp}
+import akka.cluster.seed.ZookeeperClusterSeed
 import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
-import akka.actor._
-import com.typesafe.config.{ConfigFactory, Config}
-import akka.cluster.ClusterEvent.{CurrentClusterState, MemberUp}
-import akka.cluster.Cluster
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{Random, Properties}
-import akka.cluster.ClusterEvent.MemberUp
-import akka.cluster.seed.ZookeeperClusterSeed
-import concurrent.duration._
-import org.scalatest._
+import scala.util.{Properties, Random}
 
 
-trait ScalaTestMultiNodeSpec extends MultiNodeSpecCallbacks with WordSpecLike with MustMatchers with BeforeAndAfterAll {
 
-  override def beforeAll() = multiNodeSpecBeforeAll()
 
-  override def afterAll() = multiNodeSpecAfterAll()
-
-}
-
-object ZookeeperClusterSeedrMultiNodeConfig extends MultiNodeConfig {
+object ZookeeperClusterSeedMultiNodeConfig extends MultiNodeConfig {
   val node1 = role("node1")
   val node2 = role("node2")
   val node3 = role("node3")
@@ -50,10 +40,8 @@ class ZookeeperClusterSeedMultiJvmNode3 extends ZookeeperClusterSeedSpec
 
 class ZookeeperClusterSeedMultiJvmNode4 extends ZookeeperClusterSeedSpec
 
-class ZookeeperClusterSeedSpec extends  MultiNodeSpec(ZookeeperClusterSeedrMultiNodeConfig)
+class ZookeeperClusterSeedSpec extends  MultiNodeSpec(ZookeeperClusterSeedMultiNodeConfig)
 with ScalaTestMultiNodeSpec with ImplicitSender {
-
-  import ZookeeperClusterSeedrMultiNodeConfig._
 
   def initialParticipants = roles.size
 


### PR DESCRIPTION
Akka 2.4.11 Introduced new UDP transport based on Artery, right now `akka-zk-cluster-seed` hardcoded to use `akka.tcp://` protocol, which is wrong for Artery.