### PR TITLE
Minor change of logging level

### DIFF
--- a/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
+++ b/src/main/scala/akka/cluster/seed/ZookeeperClusterSeed.scala
@@ -70,7 +70,7 @@ class ZookeeperClusterSeed(system: ExtendedActorSystem) extends Extension {
     latch.start()
     seedEntryAdded = true
     while (!tryJoin()) {
-      system.log.error("component=zookeeper-cluster-seed at=try-join-failed id={}", myId)
+      system.log.warning("component=zookeeper-cluster-seed at=try-join-failed id={}", myId)
       Thread.sleep(1000)
     }
 


### PR DESCRIPTION
When connecting, it's quite common for the first `join()` attempt to fail and a message at the `error` level to be generated. The situation is non-fatal though, generating a spurious error in the logs. 

Many deployments generate devops notifications on any error, thus reducing this to `warning` is prudent.