### PR TITLE
support for cluster clients via zookeeper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,12 +25,15 @@ val exhibitorOptionalDependencies = Seq(
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion
 ).map(_ % Provided)
 
+val curatorVersion = "2.11.0"
+
 val zkDependencies = Seq(
   "curator-framework",
   "curator-recipes"
 ).map { 
-  "org.apache.curator" % _ % "2.11.0" exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12")
+  "org.apache.curator" % _ % curatorVersion exclude("log4j", "log4j") exclude("org.slf4j", "slf4j-log4j12")
 }
+  
 
 val testDependencies = Seq(
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion,
@@ -40,7 +43,8 @@ val testDependencies = Seq(
   "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
   "org.slf4j" % "log4j-over-slf4j" % "1.7.7",
-  "ch.qos.logback" % "logback-classic" % "1.1.2"
+  "ch.qos.logback" % "logback-classic" % "1.1.2",
+  "org.apache.curator" % "curator-test" % curatorVersion
 ).map(_ % Test)
 
 lazy val rootProject = (project in file(".")).

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,9 @@
-
 import com.typesafe.sbt.SbtMultiJvm
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
 organization := "com.sclasen"
 name := "akka-zk-cluster-seed"
-version := "0.1.10-SNAPSHOT"
+version := "0.1.10-sml-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.1")
@@ -14,7 +13,8 @@ val akkaHttpVersion = "10.0.6"
 
 val akkaDependencies = Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-  "com.typesafe.akka" %% "akka-cluster" % akkaVersion
+  "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion
 )
 
 val exhibitorOptionalDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
 organization := "com.sclasen"
 name := "akka-zk-cluster-seed"
-version := "0.1.10-sml-SNAPSHOT"
+version := "0.1.10-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.1")

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ akka.clister.client.zookeeper {
     path = "/akka/cluster/seed"
     name = "myclusteractor" # this is the name of your actor system
     
-    receptionistName = "receptionist" # optional, set to 'receptionist' by default
+    receptionistName = "/system/receptionist" # optional, set to '/system/receptionist' by default
     
     // and all the connection properties you can use in your seed config like 'exhibitor' or 'authorization' etc.
 }

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ akka.clister.client.zookeeper {
 Usage in your code is as simple as
 
 ```
-val lusterClient = system.actorOf(ZookeeperClusterClientProps(system), "clusterClient")
+val clusterClient = system.actorOf(ZookeeperClusterClientProps(system), "clusterClient")
 
 ```
 

--- a/src/main/scala/akka/cluster/AkkaCuratorClient.scala
+++ b/src/main/scala/akka/cluster/AkkaCuratorClient.scala
@@ -1,0 +1,24 @@
+package akka.cluster
+
+import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
+import org.apache.curator.retry.ExponentialBackoffRetry
+
+object AkkaCuratorClient {
+  def apply(settings: ZookeeperClusterSeedSettings) : CuratorFramework = {
+    val retryPolicy = new ExponentialBackoffRetry(1000, 3)
+    val connStr = settings.ZKUrl.replace("zk://", "")
+    val curatorBuilder = CuratorFrameworkFactory.builder()
+      .connectString(connStr)
+      .retryPolicy(retryPolicy)
+
+    settings.ZKAuthorization match {
+      case Some((scheme, auth)) => curatorBuilder.authorization(scheme, auth.getBytes)
+      case None =>
+    }
+
+    val client = curatorBuilder.build()
+
+    client.start()
+    client
+  }
+}

--- a/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
+++ b/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
@@ -1,0 +1,35 @@
+package akka.cluster
+
+import akka.actor.ActorSystem
+import akka.cluster.seed.ExhibitorClient
+
+import scala.concurrent.Await
+
+import concurrent.duration._
+
+class ZookeeperClusterSeedSettings(system: ActorSystem, settingsRoot: String = "akka.cluster.seed.zookeeper") {
+
+  private val zc = system.settings.config.getConfig(settingsRoot)
+
+  val ZKUrl: String = if (zc.hasPath("exhibitor.url")) {
+    val validate = zc.getBoolean("exhibitor.validate-certs")
+    val exhibitorUrl = zc.getString("exhibitor.url")
+    val exhibitorPath = if (zc.hasPath("exhibitor.request-path")) zc.getString("exhibitor.request-path") else "/exhibitor/v1/cluster/list"
+    Await.result(ExhibitorClient(system, exhibitorUrl, exhibitorPath, validate).getZookeepers(), 10.seconds)
+  } else zc.getString("url")
+
+  val ZKPath: String = zc.getString("path")
+
+  val ZKAuthorization: Option[(String, String)] = if (zc.hasPath("authorization.scheme") && zc.hasPath("authorization.auth"))
+    Some((zc.getString("authorization.scheme"), zc.getString("authorization.auth")))
+  else None
+
+  val host: Option[String] = if (zc.hasPath("host_env_var"))
+    Some(zc.getString("host_env_var"))
+  else None
+
+  val port: Option[Int] = if (zc.hasPath("port_env_var"))
+    Some(zc.getInt("port_env_var"))
+  else None
+
+}

--- a/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
+++ b/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
@@ -2,14 +2,16 @@ package akka.cluster
 
 import akka.actor.ActorSystem
 import akka.cluster.seed.ExhibitorClient
+import com.typesafe.config.Config
 
 import scala.concurrent.Await
-
 import concurrent.duration._
 
-class ZookeeperClusterSeedSettings(system: ActorSystem, settingsRoot: String = "akka.cluster.seed.zookeeper") {
+class ZookeeperClusterSeedSettings(system: ActorSystem,
+                                   settingsRoot: String = "akka.cluster.seed.zookeeper",
+                                   overwrittenActorSettings: Option[Config] = None) {
 
-  private val zc = system.settings.config.getConfig(settingsRoot)
+  private val zc = overwrittenActorSettings.getOrElse(system.settings.config).getConfig(settingsRoot)
 
   val ZKUrl: String = if (zc.hasPath("exhibitor.url")) {
     val validate = zc.getBoolean("exhibitor.validate-certs")

--- a/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
+++ b/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
@@ -22,7 +22,7 @@ object ZookeeperClusterClientSettings {
 
     val systemName = config.getString("zookeeper.name")
 
-    val receptionistPath = "/system/" + Try(config.getString("zookeeper.receptionistName")).getOrElse("receptionist")
+    val receptionistPath = Try(config.getString("zookeeper.receptionistName")).getOrElse("/system/receptionist")
 
     val settings = new ZookeeperClusterSeedSettings(system, "akka.cluster.client.zookeeper", overwrittenActorSettings)
 

--- a/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
+++ b/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
@@ -1,0 +1,58 @@
+package akka.cluster.client
+
+import akka.actor.{ActorSystem, Props}
+import akka.cluster.{AkkaCuratorClient, ZookeeperClusterSeedSettings}
+import com.typesafe.config.ConfigValueFactory
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.recipes.locks.{LockInternals, LockInternalsSorter, StandardLockInternalsDriver}
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable
+import scala.util.Try
+
+object ZookeeperClusterClientSettings {
+
+  private val sorter = new LockInternalsSorter() {
+    override def fixForSorting(str: String, lockName: String): String =
+      StandardLockInternalsDriver.standardFixForSorting(str, lockName)
+  }
+
+  def apply(system: ActorSystem): ClusterClientSettings = {
+    val config = system.settings.config.getConfig("akka.cluster.client")
+
+    val systemName = config.getString("zookeeper.name")
+
+    val receptionistPath = "/system/" + Try(config.getString("zookeeper.receptionistName")).getOrElse("receptionist")
+
+    val settings = new ZookeeperClusterSeedSettings(system, "akka.cluster.client.zookeeper")
+
+    val client = AkkaCuratorClient(settings)
+
+    val contacts = getClusterParticipants(client, settings.ZKPath + "/" + systemName).map(_ + receptionistPath)
+
+    system.log.warning("component=zookeeper-cluster-client at=find-initial-contacts contacts={}", contacts)
+
+    client.close()
+
+    ClusterClientSettings(
+      config.withValue(
+        "initial-contacts",
+        ConfigValueFactory.fromIterable(immutable.List(contacts: _*).asJava)
+      )
+    )
+  }
+
+  private def getClusterParticipants(client: CuratorFramework, zkPath: String): Seq[String] =  {
+    val participants = LockInternals.getParticipantNodes(client,
+      zkPath,
+      "latch-" /* magic string from LeaderLatch.LOCK_NAME */,
+      sorter).asScala
+
+    participants.map(path => new String(client.getData.forPath(path))).toSeq
+  }
+
+}
+
+object ZookeeperClusterClientProps {
+  def apply(system: ActorSystem): Props = ClusterClient.props(ZookeeperClusterClientSettings(system))
+}

--- a/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
+++ b/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
@@ -2,7 +2,7 @@ package akka.cluster.client
 
 import akka.actor.{ActorSystem, Props}
 import akka.cluster.{AkkaCuratorClient, ZookeeperClusterSeedSettings}
-import com.typesafe.config.ConfigValueFactory
+import com.typesafe.config.{Config, ConfigValueFactory}
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.locks.{LockInternals, LockInternalsSorter, StandardLockInternalsDriver}
 
@@ -17,14 +17,14 @@ object ZookeeperClusterClientSettings {
       StandardLockInternalsDriver.standardFixForSorting(str, lockName)
   }
 
-  def apply(system: ActorSystem): ClusterClientSettings = {
-    val config = system.settings.config.getConfig("akka.cluster.client")
+  def apply(system: ActorSystem, overwrittenActorSettings: Option[Config] = None): ClusterClientSettings = {
+    val config = overwrittenActorSettings.getOrElse(system.settings.config).getConfig("akka.cluster.client")
 
     val systemName = config.getString("zookeeper.name")
 
     val receptionistPath = "/system/" + Try(config.getString("zookeeper.receptionistName")).getOrElse("receptionist")
 
-    val settings = new ZookeeperClusterSeedSettings(system, "akka.cluster.client.zookeeper")
+    val settings = new ZookeeperClusterSeedSettings(system, "akka.cluster.client.zookeeper", overwrittenActorSettings)
 
     val client = AkkaCuratorClient(settings)
 

--- a/src/test/scala/akka/cluster/integration/ZookeeperClientIntegrationTests.scala
+++ b/src/test/scala/akka/cluster/integration/ZookeeperClientIntegrationTests.scala
@@ -1,0 +1,57 @@
+package akka.cluster.integration
+
+import akka.actor.{ActorPath, ActorSystem}
+import akka.cluster.client.ZookeeperClusterClientSettings
+import akka.cluster.seed.ZookeeperClusterSeed
+import akka.testkit.TestKit
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+
+class ZookeeperClientIntegrationTests extends TestKit(
+  ActorSystem("test", ZookeeperClientIntegrationSettingsSpec.config(ZookeeperHelper.server.getConnectString)))
+  with WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  import ZookeeperHelper._
+
+  "ZookeeperClientIntegrationTests " should {
+    "register in zookeper" in {
+      // given
+      ZookeeperClusterSeed(system).join()
+
+      // when
+      val clusterSettings = ZookeeperClusterClientSettings(system)
+
+      // then
+      clusterSettings.initialContacts shouldBe Set(ActorPath.fromString(s"${selfAddress(system)}/system/receptionist"))
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+    stopZK()
+  }
+}
+
+object ZookeeperClientIntegrationSettingsSpec {
+  // these settings will be used for both cluster and client
+  def config(zkUrl: String): Config = ConfigFactory.parseString(s"""
+         akka{
+            actor {
+              provider = "akka.cluster.ClusterActorRefProvider"
+            }
+            cluster {
+              seed.zookeeper {
+                url = "${zkUrl}"
+                path = "/akka/cluster/seed"
+              }
+
+              client.zookeeper {
+                url = "${zkUrl}"
+                path = "/akka/cluster/seed"
+                name = "test"
+              }
+            }
+         }
+       """)
+}

--- a/src/test/scala/akka/cluster/integration/ZookeeperHelper.scala
+++ b/src/test/scala/akka/cluster/integration/ZookeeperHelper.scala
@@ -1,0 +1,55 @@
+package akka.cluster.integration
+
+import akka.actor.ActorSystem
+import akka.cluster.Cluster
+import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
+import org.apache.curator.retry.RetryOneTime
+import org.apache.curator.test.TestingServer
+
+import scala.collection.JavaConverters._
+
+object ZookeeperHelper {
+
+  val zookeepers = new ThreadLocal[TestingServer]
+
+  def server: TestingServer = {
+    if (zookeepers.get() == null) startZK()
+    zookeepers.get()
+  }
+
+  def getChildren(path: String): List[String] = {
+    val client = newClient
+    val children = client.getChildren.forPath(path)
+    client.close()
+    children.asScala.toList
+  }
+
+  def readPath(path: String): String = {
+    println(s"reading path $path")
+    val client = newClient
+    val data = new String(client.getData.forPath(path))
+    client.close()
+    data
+  }
+
+  def selfAddress(system: ActorSystem): String = Cluster(system).selfAddress.toString
+
+  def stopZK(): Unit = {
+    server.close()
+    zookeepers.remove()
+  }
+
+  def startZK(): Unit = {
+    val server = new TestingServer()
+    zookeepers.set(server)
+  }
+
+  private def newClient: CuratorFramework = {
+    val client = CuratorFrameworkFactory.builder()
+      .connectString(server.getConnectString)
+      .retryPolicy(new RetryOneTime(1000))
+      .build()
+    client.start()
+    client
+  }
+}

--- a/src/test/scala/akka/cluster/integration/ZookeeperSeedIntegrationTests.scala
+++ b/src/test/scala/akka/cluster/integration/ZookeeperSeedIntegrationTests.scala
@@ -1,0 +1,48 @@
+package akka.cluster.integration
+
+import akka.actor.ActorSystem
+import akka.cluster.seed.ZookeeperClusterSeed
+import akka.testkit.TestKit
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+class ZookeeperSeedIntegrationTests extends TestKit(
+  ActorSystem("test", ZookeeperSeedIntegrationSettingsSpec.config(ZookeeperHelper.server.getConnectString)))
+  with WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  import ZookeeperHelper._
+
+  "ZookeeperSeedIntegrationTests " should {
+    "register in zookeper" in {
+      // given
+      ZookeeperClusterSeed(system).join()
+
+      val registerPath = "/akka/cluster/seed/test"
+
+      // expect
+      val registeredNodes = getChildren(registerPath)
+      registeredNodes should have size 1
+
+      readPath(registerPath + "/" + registeredNodes.head) shouldBe selfAddress(system)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+    stopZK()
+  }
+}
+
+object ZookeeperSeedIntegrationSettingsSpec {
+  def config(zkUrl: String): Config = ConfigFactory.parseString(s"""
+         akka{
+            actor {
+              provider = "akka.cluster.ClusterActorRefProvider"
+            }
+            cluster.seed.zookeeper {
+              url = "${zkUrl}"
+              path = "/akka/cluster/seed"
+            }
+         }
+       """)
+}

--- a/src/test/scala/akka/cluster/seed/ZookeeperClusterSeedSettingsSpec.scala
+++ b/src/test/scala/akka/cluster/seed/ZookeeperClusterSeedSettingsSpec.scala
@@ -1,9 +1,10 @@
 package akka.cluster.seed
 
 import akka.actor.ActorSystem
+import akka.cluster.ZookeeperClusterSeedSettings
 import akka.testkit.TestKit
-import com.typesafe.config.{ ConfigFactory, Config }
-import org.scalatest.{ Matchers, WordSpecLike }
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{Matchers, WordSpecLike}
 
 class ZookeeperClusterSeedSettingsSpec extends TestKit(ActorSystem("test", ZookeeperClusterSeedSettingsSpec.config))
     with WordSpecLike with Matchers {


### PR DESCRIPTION
Ok, to be honest i meant to have this pull request locally first, but well :))

What i've added here:
- ability to use `akka.cluster.client.ClusterClient` that would resolve it's initial-contacts from zookeeper
- integration tests to check if the whole thing works (for both seeds and clients)

what works:
- the code for connecting to zookeeper is shared across seeds and clients - in theory all exhibitors, authentications etc. should Just Work ™️

gotchas:
- the library has an extra dependency to akka-cluster-tools in order to be able to use `ClusterClient` code