### PR TITLE
zookeeper-based auto downing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
 organization := "com.sclasen"
 name := "akka-zk-cluster-seed"
-version := "0.1.10-SNAPSHOT"
+version := "0.1.10-sml-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.1")

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
 organization := "com.sclasen"
 name := "akka-zk-cluster-seed"
-version := "0.1.10-sml-SNAPSHOT"
+version := "0.1.10-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.1")

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,16 @@ akka.cluster.seed.zookeeper {
 }
 ```
 
+Auto-downing of nodes when they're unregistered from zookeeper:
+
+```
+// aplication.conf
+akka.cluster.see.zookeeper {
+    auto-down = true # optional. default is false
+}
+
+```
+
 
 details
 -------

--- a/readme.md
+++ b/readme.md
@@ -190,15 +190,15 @@ Your application bootstrap code (given you have two clusters called `foo` and `b
 
 val zookeeperClusterSettings = system.settings.config
 
-val clusterClientToFoo = ClusterClient.props(
+val clusterClientToFoo = system.actorOf(ClusterClient.props(
         ZookeeperClusterClientSettings(
           system, 
           Some(zookeeperClusterSettings.withValue("name", ConfigValueFactory.fromAnyRef("foo"))))
-      )
+      ), "clusterClientFoo")
     
-val clusterClientToBar = ClusterClient.props(
+val clusterClientToBar = system.actorOf(ClusterClient.props(
         ZookeeperClusterClientSettings(
           system, 
           Some(zookeeperClusterSettings.withValue("name", ConfigValueFactory.fromAnyRef("bar"))))
-      )
+      ), "clusterClientBar")
 ``` 

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,22 @@ The two extra options `wait-for-leader` and `unresolved-strategy` are used to co
 `unresolved-strategy` you can either choose to log a warning should the process times out or force downing of the removed
 node which in that case will be performed from all the notified nodes. 
 
+### Shutdown on zookeeper disconnect
+
+Especially when using zookeeper auto-downing it might be problematic that once a node gets kicked out from the cluster
+by other nodes there is no good recovery plans once it reconnects.
+
+You might choose the application to shutdown once that happens. If you are using auto-scaling deployment environments like
+DC/OS the container will take care of restarting your app. This might be the best approach as you will not end up with
+some weird states preserved within your actors.
+
+```yaml
+// aplication.conf
+akka.cluster.seed.zookeeper {
+    shutdown-on-disconnect = true # false by default
+}
+```
+
 details
 -------
 

--- a/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
+++ b/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
@@ -47,6 +47,8 @@ class ZookeeperClusterSeedSettings(system: ActorSystem,
       AutoDownUnresolvedStrategies.Log
     } else strategy
   }.getOrElse(AutoDownUnresolvedStrategies.Log)
+
+  val autoShutdown: Boolean = Try(zc.getBoolean("shutdown-on-disconnect")).getOrElse(false)
 }
 
 object AutoDownUnresolvedStrategies {

--- a/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
+++ b/src/main/scala/akka/cluster/ZookeeperClusterSeedSettings.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 
 import scala.concurrent.Await
 import concurrent.duration._
+import scala.util.Try
 
 class ZookeeperClusterSeedSettings(system: ActorSystem,
                                    settingsRoot: String = "akka.cluster.seed.zookeeper",
@@ -33,5 +34,7 @@ class ZookeeperClusterSeedSettings(system: ActorSystem,
   val port: Option[Int] = if (zc.hasPath("port_env_var"))
     Some(zc.getInt("port_env_var"))
   else None
+
+  val autoDown: Boolean = Try(zc.getBoolean("auto-down")).getOrElse(false)
 
 }

--- a/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
+++ b/src/main/scala/akka/cluster/client/ZookeeperClusterClientSettings.scala
@@ -30,7 +30,7 @@ object ZookeeperClusterClientSettings {
 
     val contacts = getClusterParticipants(client, settings.ZKPath + "/" + systemName).map(_ + receptionistPath)
 
-    system.log.warning("component=zookeeper-cluster-client at=find-initial-contacts contacts={}", contacts)
+    system.log.info("component=zookeeper-cluster-client at=find-initial-contacts contacts={}", contacts)
 
     client.close()
 

--- a/src/test/scala/akka/cluster/seed/ZookeeperAutoDowningIntegrationSpec.scala
+++ b/src/test/scala/akka/cluster/seed/ZookeeperAutoDowningIntegrationSpec.scala
@@ -1,0 +1,110 @@
+package akka.cluster.seed
+
+import akka.actor.ActorSystem
+import akka.cluster.integration.ZookeeperHelper
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class ZookeeperAutoDowningIntegrationSpec extends WordSpec with Matchers with Eventually {
+
+  import ZookeeperHelper._
+
+  implicit override val patienceConfig =
+    PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = scaled(Span(1, Seconds)))
+
+  def findLeader(seeds: List[(ZookeeperClusterSeed, ActorSystem)]): (ZookeeperClusterSeed, ActorSystem) =
+    seeds.find(_._1.isLeader()).get
+
+  "ZookeeperAutoDowning" should {
+    "auto down when leader killed" in {
+      // given
+      val system1 = ActorSystem("system-leader",
+        ZookeeperAutoDowningIntegrationSettingsSpec.config(server.getConnectString, 2253))
+      val zkS1 = ZookeeperClusterSeed(system1)
+      zkS1.join()
+
+      val system2 = ActorSystem("system-leader",
+        ZookeeperAutoDowningIntegrationSettingsSpec.config(server.getConnectString, 2554))
+      val zkS2 = ZookeeperClusterSeed(system2)
+      zkS2.join()
+
+      val system3 = ActorSystem("system-leader",
+        ZookeeperAutoDowningIntegrationSettingsSpec.config(server.getConnectString, 2555))
+      val zkS3 = ZookeeperClusterSeed(system3)
+      zkS3.join()
+
+      val allZks = List((zkS1, system1), (zkS2, system2), (zkS3, system3))
+
+      // expect
+      val leader = findLeader(allZks)
+      val nonLeader = allZks.filter(_ != leader).head
+
+      Await.result(leader._2.terminate(), 10 seconds)
+      nonLeader._1.clusterSystem.state.members.find(_.address == leader._1.clusterSystem.selfAddress) shouldBe defined
+
+      eventually {
+        nonLeader._1.clusterSystem.state.members.find(_.address == leader._1.clusterSystem.selfAddress) shouldBe None
+      }
+    }
+
+    "auto down when non-leader killed" in {
+      // given
+      val system1 = ActorSystem("system-nonleader",
+        ZookeeperAutoDowningIntegrationSettingsSpec.config(server.getConnectString, 2256))
+      val zkS1 = ZookeeperClusterSeed(system1)
+      zkS1.join()
+
+      val system2 = ActorSystem("system-nonleader",
+        ZookeeperAutoDowningIntegrationSettingsSpec.config(server.getConnectString, 2557))
+      val zkS2 = ZookeeperClusterSeed(system2)
+      zkS2.join()
+
+      val system3 = ActorSystem("system-nonleader",
+        ZookeeperAutoDowningIntegrationSettingsSpec.config(server.getConnectString, 2558))
+      val zkS3 = ZookeeperClusterSeed(system3)
+      zkS3.join()
+
+      val allZks = List((zkS1, system1), (zkS2, system2), (zkS3, system3))
+
+      // expect
+      val leader = findLeader(allZks)
+      val nonLeader = allZks.filter(_ != leader).head
+
+      Await.result(nonLeader._2.terminate(), 10 seconds)
+      leader._1.clusterSystem.state.members.find(_.address == nonLeader._1.clusterSystem.selfAddress) shouldBe defined
+
+      eventually {
+        leader._1.clusterSystem.state.members.find(_.address == nonLeader._1.clusterSystem.selfAddress) shouldBe None
+      }
+    }
+  }
+
+}
+
+object ZookeeperAutoDowningIntegrationSettingsSpec {
+  def config(zkUrl: String, port: Int): Config = ConfigFactory.parseString(
+    s"""
+         akka{
+            actor {
+              provider = "akka.cluster.ClusterActorRefProvider"
+            }
+            cluster.seed.zookeeper {
+              url = "${zkUrl}"
+              path = "/akka/cluster/seed"
+              auto-down {
+                  enabled = true
+              }
+            }
+            remote {
+              netty.tcp {
+                port = ${port}
+              }
+            }
+         }
+       """)
+}


### PR DESCRIPTION
OK, another pull request. I could use another pair of eyes on it.

So what is it - there's a known problem of auto downing in akka, which you have surely heard of, but basically the problem is that when a node in a cluster dies the rest of the nodes freak out and as long as the node doesn't come back or is not downed the cluster doesn't work.

What you can do is use `auto-down-unreachable-after` which will trigger auto-downing after some time of a node being unreachable. It is highly unrecommended because it doesn't handle network partitions well and you might end up with seriously broken cluster (more info at https://doc.akka.io/docs/akka/2.5.3/scala/cluster-usage.html )

OK, enough introduction. Here I'm treating zookeeper as a single point of truth of which nodes are reachable from the cluster and which are not. Once a node unregisters from zookeeper, we will treat it as a gone one and have current leader down it in the cluster.

There are some settings on how long should it wait for a leader re-election (if the leader died) etc. more on readme.

WDYT? Does that make sense?