### PR TITLE
Bump version, upgrade apache curator to 4.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
 organization := "com.sclasen"
 name := "akka-zk-cluster-seed"
-version := "0.1.11-SNAPSHOT"
+version := "0.2.0-SNAPSHOT"
 
 scalaVersion := "2.12.4"
 crossScalaVersions := Seq(scalaVersion.value, "2.11.11")
@@ -25,7 +25,7 @@ val exhibitorOptionalDependencies = Seq(
   "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpVersion
 ).map(_ % Provided)
 
-val curatorVersion = "2.12.0"
+val curatorVersion = "4.0.0"
 
 val zkDependencies = Seq(
   "curator-framework",


### PR DESCRIPTION
@sclasen 

I'm not sure what needs to be updated, but I 
1) bumped the version of Apache Curator
2) bumped the SNAPSHOT version of the library itself one minor version to `0.2.0`, since this is a breaking library version upgrade.

I did NOT touch any other dependency versions as I didn't want to rock the boat too much :).

Thanks very much for taking a look at it!